### PR TITLE
Fix python logging encoding

### DIFF
--- a/backend/python/app.py
+++ b/backend/python/app.py
@@ -72,7 +72,6 @@ def process(message: str, db: Memgraph):
 if __name__ == "__main__":
     logging.basicConfig(
         filename="info.log",
-        encoding="utf-8",
         level=logging.INFO,
         format="%(levelname)s: %(asctime)s %(message)s",
     )


### PR DESCRIPTION
It seems that some Python versions (e.g. `3.8.10`) don't have the `encoding` parameter.