### PR TITLE
fix memgraph version

### DIFF
--- a/memgraph/run.sh
+++ b/memgraph/run.sh
@@ -35,7 +35,7 @@ memgraph_docker_name="memgraph_streaming_app"
 execute () {
     action=$1
     if [ -f "$script_dir/queries/$action.cypher" ]; then
-        cat < "$script_dir/queries/$action.cypher" | docker run -i --rm --network host --entrypoint mgconsole "$memgraph_docker_image" || memgraph_help_and_exit
+        cat < "$script_dir/queries/$action.cypher" | docker run --pull always -i --rm --network host --entrypoint mgconsole "$memgraph_docker_image" || memgraph_help_and_exit
     else
         script_help_and_exit
     fi


### PR DESCRIPTION
closes #21

I added the `--pull always` flag to the `docker run` command.
It seems weird that docker verifies the hash multiple times before running:
```
 memgraph fix-memgraph-version ✗ bash run.sh memgraph
19a3f4efbe827fb1bdb5d67241f424d5dec1820627b265b25e5eeda13e65c213
Starting memgraph...
latest: Pulling from memgraph/memgraph
Digest: sha256:9a45e6ad18f28edcc1e8317eb225041a3c017b7841b43d994d90155c97efd905
Status: Image is up to date for memgraph/memgraph:latest
latest: Pulling from memgraph/memgraph
Digest: sha256:9a45e6ad18f28edcc1e8317eb225041a3c017b7841b43d994d90155c97efd905
Status: Image is up to date for memgraph/memgraph:latest
latest: Pulling from memgraph/memgraph
Digest: sha256:9a45e6ad18f28edcc1e8317eb225041a3c017b7841b43d994d90155c97efd905
Status: Image is up to date for memgraph/memgraph:latest
latest: Pulling from memgraph/memgraph
Digest: sha256:9a45e6ad18f28edcc1e8317eb225041a3c017b7841b43d994d90155c97efd905
Status: Image is up to date for memgraph/memgraph:latest
```